### PR TITLE
Changed puppet repo to global EL 7 repo

### DIFF
--- a/install-puppet-agent-redhat.sh
+++ b/install-puppet-agent-redhat.sh
@@ -21,8 +21,8 @@ if command -v lsb_release > /dev/null 2>&1; then
 			VERSION=`lsb_release -sr | cut -d. -f1`;
 else
         # Puppet agent needs this. But we can use system-release-cp for version determination too.
-        yum install redhat-lsb-core -y
-        
+		yum install redhat-lsb-core -y
+
 		if [ ! -f /etc/system-release-cpe ]; then
 			echo "Cannot determine OS release/version, not good.";
 			exit 1;

--- a/install-puppet-agent-redhat.sh
+++ b/install-puppet-agent-redhat.sh
@@ -20,7 +20,16 @@ if command -v lsb_release > /dev/null 2>&1; then
 			lsb_release -a;
 			VERSION=`lsb_release -sr | cut -d. -f1`;
 else
-		yum install redhat-lsb-core
+        # Puppet agent needs this. But we can use system-release-cp for version determination too.
+        yum install redhat-lsb-core -y
+        
+		if [ ! -f /etc/system-release-cpe ]; then
+			echo "Cannot determine OS release/version, not good.";
+			exit 1;
+		else
+			echo "Installing for: `cat /etc/system-release-cpe`";
+			VERSION=`cat /etc/system-release-cpe | cut -d: -f5`
+		fi
 fi
 
 # CLOUD-INIT HOSTNAME PRESERVATION

--- a/install-puppet-agent-redhat.sh
+++ b/install-puppet-agent-redhat.sh
@@ -15,20 +15,12 @@ else
 fi
 
 # VERSION DETECTION
-MINOR=11
 if command -v lsb_release > /dev/null 2>&1; then
 			echo "installing for:";
 			lsb_release -a;
 			VERSION=`lsb_release -sr | cut -d. -f1`;
-			MINOR=`lsb_release -sr | cut -d. -f2`;
 else
-		if [ ! -f /etc/system-release-cpe ]; then
-			echo "Cannot determine OS release/version, not good.";
-			exit 1;
-		else
-			echo "Installing for: `cat /etc/system-release-cpe`";
-			VERSION=`cat /etc/system-release-cpe | cut -d: -f5`
-		fi
+		yum install redhat-lsb-core
 fi
 
 # CLOUD-INIT HOSTNAME PRESERVATION
@@ -57,7 +49,7 @@ else
 fi
 
 # INSTALL PUPPET
-rpm -ivh http://yum.puppetlabs.com/el/${VERSION}/products/`uname -i`/puppetlabs-release-${VERSION}-${MINOR}.noarch.rpm
+rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-el-${VERSION}.noarch.rpm
 yum clean all
 yum install puppet -y
 


### PR DESCRIPTION
Changed repository for puppet to the one as documented at: https://dcs.puppet.com/guides/puppetlabs_package_repositories.html. The previous repo name contained the minor version which breaks with the current installation of CentOS (7.2). The new repository always installs the latest version. Also added the installation of redhat-lsb-core because this package was missing and is required by Puppet
